### PR TITLE
 Always require warnings and enable -Werror and Wextra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,20 +9,16 @@ if(PROJECT_BINARY_DIR STREQUAL PROJECT_SOURCE_DIR)
    message(FATAL_ERROR "In-tree build attempt detected, aborting. Set your build dir outside your source dir, delete CMakeCache.txt from source root and try again.")
 endif()
 
-option(basic_warnings "Basic compiler warnings." ON)
 option(private_dbus "Use private dbus namespace to prevent clashes during development." OFF)
 
 include(cmake/coverage.cmake)
 include(FindPkgConfig)
 include (GNUInstallDirs)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 add_definitions(-DQT_NO_KEYWORDS)
 
-if(${basic_warnings})
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
-endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Werror -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -Wall -pedantic -Werror -Wextra")
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ include (GNUInstallDirs)
 add_definitions(-DQT_NO_KEYWORDS)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Werror -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -Wall -pedantic -Werror -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra")
+set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/ActionModel.cpp
+++ b/src/ActionModel.cpp
@@ -27,7 +27,7 @@ ActionModel::ActionModel(QObject *parent) : QStringListModel(parent), p(new Acti
 ActionModel::~ActionModel() {
 }
 
-int ActionModel::rowCount(const QModelIndex &index) const {
+int ActionModel::rowCount(const QModelIndex & /* index */) const {
     return p->labels.size();
 }
 

--- a/src/NotificationClientPlugin.cpp
+++ b/src/NotificationClientPlugin.cpp
@@ -30,7 +30,7 @@ void NotificationClientPlugin::registerTypes(const char *uri) {
     qmlRegisterUncreatableType<NotificationClient>(uri, 1, 0, "NotificationClient", QString());
 }
 
-void NotificationClientPlugin::initializeEngine(QQmlEngine *engine, const char *uri) {
+void NotificationClientPlugin::initializeEngine(QQmlEngine *engine, const char * /* uri */) {
     NotificationClient *cl = new NotificationClient(QDBusConnection::sessionBus(), engine);
     engine->rootContext()->setContextProperty("notificationclient", cl);
 }

--- a/src/NotificationModel.cpp
+++ b/src/NotificationModel.cpp
@@ -65,7 +65,7 @@ NotificationModel::~NotificationModel() {
     }
 }
 
-int NotificationModel::rowCount(const QModelIndex &parent) const {
+int NotificationModel::rowCount(const QModelIndex & /* parent */) const {
     //printf("Count %d\n", p->displayedNotifications.size());
     return p->displayedNotifications.size();
 }

--- a/src/NotificationPlugin.cpp
+++ b/src/NotificationPlugin.cpp
@@ -50,7 +50,7 @@ void NotificationPlugin::registerTypes(const char *uri) {
     qmlRegisterUncreatableType<ActionModel>(uri, 1, 0, "ActionModel", "Abstract Interface. Cannot be instantiated.");
 }
 
-void NotificationPlugin::initializeEngine(QQmlEngine *engine, const char *uri) {
+void NotificationPlugin::initializeEngine(QQmlEngine *engine, const char * /* uri */) {
     m = new NotificationModel();
     s = new NotificationServer(QDBusConnection::sessionBus(), *m, engine);
 }

--- a/src/NotificationServer.cpp
+++ b/src/NotificationServer.cpp
@@ -178,7 +178,7 @@ void NotificationServer::serviceUnregistered(const QString &clientId) {
 unsigned int NotificationServer::Notify(const QString &app_name, uint replaces_id,
                            const QString &app_icon, const QString &summary,
                            const QString &body, const QStringList &actions,
-                           const QVariantMap &hints, int expire_timeout) {
+                           const QVariantMap &hints, int /* expire_timeout */) {
     const unsigned int FAILURE = 0;
     const int minActions = 4;
     const int maxActions = 14;

--- a/test/notificationservertest.cpp
+++ b/test/notificationservertest.cpp
@@ -83,7 +83,7 @@ int notifyFirst(const QString& name, int replacesId = 0) {
     return _notify(notificationsInterface, name, replacesId);
 }
 
-int notifySecond(const QString& name, int replacesId = 0, bool secondInterface = false) {
+int notifySecond(const QString& name, int replacesId = 0) {
     return _notify(secondNotificationsInterface, name, replacesId);
 }
 

--- a/test/notificationtest.cpp
+++ b/test/notificationtest.cpp
@@ -53,8 +53,8 @@ void TestNotifications::testTypeSimple() {
 
 void TestNotifications::testOrder() {
     const int timeout = 1000;
-    static NotificationModel *m = new NotificationModel(this);
-    static NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
+    NotificationModel *m = new NotificationModel(this);
+    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
     QStringList actions;
     QVariantMap hints;
     int id[4];
@@ -286,8 +286,8 @@ void TestNotifications::testReverseClose() {
     QSKIP("Crashing here in CI on all archs");
     const int timeout = 1000;
     const int max = 20;
-    static NotificationModel *m = new NotificationModel();
-    static NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
+    NotificationModel *m = new NotificationModel();
+    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
     QStringList actions;
     QVariantMap hints;
     int before = m->numNotifications();

--- a/test/notificationtest.cpp
+++ b/test/notificationtest.cpp
@@ -54,7 +54,7 @@ void TestNotifications::testTypeSimple() {
 void TestNotifications::testOrder() {
     const int timeout = 1000;
     NotificationModel *m = new NotificationModel(this);
-    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
+    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m, this);
     QStringList actions;
     QVariantMap hints;
     int id[4];
@@ -112,9 +112,6 @@ void TestNotifications::testOrder() {
     QVERIFY(!m->showingNotification(id[1]));
     QVERIFY(!m->showingNotification(id[2]));
     QCOMPARE(m->queued(), 0);
-
-    delete s;
-    delete m;
 }
 
 void TestNotifications::testHas() {
@@ -286,8 +283,8 @@ void TestNotifications::testReverseClose() {
     QSKIP("Crashing here in CI on all archs");
     const int timeout = 1000;
     const int max = 20;
-    NotificationModel *m = new NotificationModel();
-    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m);
+    NotificationModel *m = new NotificationModel(this);
+    NotificationServer *s = new NotificationServer(QDBusConnection::sessionBus(), *m, this);
     QStringList actions;
     QVariantMap hints;
     int before = m->numNotifications();
@@ -311,9 +308,6 @@ void TestNotifications::testReverseClose() {
     }
 
     QCOMPARE(m->numNotifications(), before);
-
-    delete s;
-    delete m;
 }
 
 QTEST_MAIN(TestNotifications)


### PR DESCRIPTION
We should have a strict coding policy, this way we can let the compiler
catch potential issues, but also keep up a strict policy on the code.

